### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"homepage": "https://github.com/vanruesc/grunt-fs-inline",
 	"main": "tasks/fs-inline.js",
 	"license": "Zlib",
-
 	"keywords": [
 		"grunt",
 		"gruntplugin",
@@ -13,44 +12,36 @@
 		"inline",
 		"fs"
 	],
-
 	"author": {
 		"name": "Raoul van Rüschen",
 		"email": "vanruesc@outlook.de"
 	},
-
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/vanruesc/grunt-fs-inline.git"
 	},
-
 	"bugs": {
 		"url": "https://github.com/vanruesc/grunt-fs-inline/issues"
 	},
-
 	"engines": {
 		"node": ">= 0.8.0"
 	},
-
 	"scripts": {
 		"test": "node grunt-cli.js"
 	},
-
 	"dependencies": {
 		"async-waterfall": "0.1.x",
 		"brfs": "1.4.x",
 		"glob": "6.0.x",
 		"mkdirp": "0.5.x"
 	},
-
 	"devDependencies": {
 		"grunt": "0.4.x",
 		"grunt-contrib-clean": "0.5.x",
 		"grunt-contrib-jshint": "0.9.x",
 		"grunt-contrib-nodeunit": "0.3.x"
 	},
-
 	"peerDependencies": {
-		"grunt": "0.4.x"
+		"grunt": ">=0.4.0"
 	}
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
